### PR TITLE
Test and fix for empty inline tables

### DIFF
--- a/Tomlet.Tests/InlineTableTests.cs
+++ b/Tomlet.Tests/InlineTableTests.cs
@@ -17,9 +17,10 @@ namespace Tomlet.Tests
         {
             var document = GetDocument(TestResources.BasicInlineTableTestInput);
             
-            Assert.Equal(3, document.Entries.Count);
+            Assert.Equal(4, document.Entries.Count);
             
             Assert.NotNull(document.GetSubTable("name"));
+            Assert.NotNull(document.GetSubTable("empty"));
             Assert.NotNull(document.GetSubTable("point"));
             Assert.NotNull(document.GetSubTable("animal"));
         }

--- a/Tomlet.Tests/TestResources.resx
+++ b/Tomlet.Tests/TestResources.resx
@@ -201,6 +201,7 @@ fruit . flavor = "banana"   # same as fruit.flavor</value>
     </data>
     <data name="BasicInlineTableTestInput" xml:space="preserve">
         <value>name = { first = "Tom", last = "Preston-Werner" }
+empty = {   }
 point = { x = 1, y = 2 }
 animal = { type.name = "pug" }</value>
     </data>

--- a/Tomlet/TomlParser.cs
+++ b/Tomlet/TomlParser.cs
@@ -670,6 +670,10 @@ namespace Tomlet
                 if (!reader.TryPeek(out var nextChar))
                     throw new TomlEOFException(_lineNumber);
 
+				//Note that this is only needed when we first enter the loop, in case of an empty inline table
+				if (nextChar.IsEndOfInlineObjectChar())
+					break;
+
                 //Newlines are not permitted
                 if (nextChar.IsNewline())
                     throw new NewLineInTomlInlineTableException(_lineNumber);

--- a/Tomlet/TomlParser.cs
+++ b/Tomlet/TomlParser.cs
@@ -670,9 +670,9 @@ namespace Tomlet
                 if (!reader.TryPeek(out var nextChar))
                     throw new TomlEOFException(_lineNumber);
 
-				//Note that this is only needed when we first enter the loop, in case of an empty inline table
-				if (nextChar.IsEndOfInlineObjectChar())
-					break;
+                //Note that this is only needed when we first enter the loop, in case of an empty inline table
+                if (nextChar.IsEndOfInlineObjectChar())
+                    break;
 
                 //Newlines are not permitted
                 if (nextChar.IsNewline())


### PR DESCRIPTION
Previously deserialization errored when getting a valid toml file in the form:
`empty = {   }`

Such a field is currently generated when serializing an array of a class, which seems to be a different bug:
```[Serializeable]
public class SomeClass
{
    public OtherClass[] OtherClasses;
}

[Serializeable]
public class OtherClass
{
    public int SomeValue;
}
```