### PR TITLE
Fixed support for multiple subtables

### DIFF
--- a/Tomlet.Tests/TestResources.Designer.cs
+++ b/Tomlet.Tests/TestResources.Designer.cs
@@ -201,6 +201,12 @@ namespace Tomlet.Tests {
         ///[[fruits]]
         ///name = &quot;banana&quot;
         ///
+        ///[fruits.physical.newtonian]
+        ///weight = 118 
+        ///
+        ///[fruits.physical]
+        ///color = &quot;yellow&quot;
+        ///
         ///[[fruits.varieties]]
         ///name = &quot;plantain&quot;.
         /// </summary>

--- a/Tomlet.Tests/TestResources.Designer.cs
+++ b/Tomlet.Tests/TestResources.Designer.cs
@@ -187,6 +187,10 @@ namespace Tomlet.Tests {
         ///color = &quot;red&quot;
         ///shape = &quot;round&quot;
         ///
+        ///[fruits.jam] # second subtable
+        ///color = &quot;yellow&quot;
+        ///feel = &quot;sticky&quot;
+        ///
         ///[[fruits.varieties]]  # nested array of tables
         ///name = &quot;red delicious&quot;
         ///

--- a/Tomlet.Tests/TestResources.resx
+++ b/Tomlet.Tests/TestResources.resx
@@ -258,6 +258,12 @@ name = "granny smith"
 [[fruits]]
 name = "banana"
 
+[fruits.physical.newtonian]
+weight = 118 
+
+[fruits.physical]
+color = "yellow"
+
 [[fruits.varieties]]
 name = "plantain"</value>
     </data>

--- a/Tomlet.Tests/TestResources.resx
+++ b/Tomlet.Tests/TestResources.resx
@@ -244,6 +244,10 @@ name = "apple"
 color = "red"
 shape = "round"
 
+[fruits.jam] # second subtable
+color = "yellow"
+feel = "sticky"
+
 [[fruits.varieties]]  # nested array of tables
 name = "red delicious"
 

--- a/Tomlet.Tests/TomlTableArrayTests.cs
+++ b/Tomlet.Tests/TomlTableArrayTests.cs
@@ -76,7 +76,7 @@ namespace Tomlet.Tests
         [Fact]
         public void DefiningATableArrayWithTheSameNameAsATableThrowsAnException()
         {
-            Assert.Throws<TomlTableArrayAlreadyExistsAsNonArrayException>(() => GetDocument(TestResources.DefiningAsArrayWhenAlreadyTableTestInput));
+            Assert.Throws<TomlTypeMismatchException>(() => GetDocument(TestResources.DefiningAsArrayWhenAlreadyTableTestInput));
         }
 
         [Fact]

--- a/Tomlet.Tests/TomlTableArrayTests.cs
+++ b/Tomlet.Tests/TomlTableArrayTests.cs
@@ -81,7 +81,7 @@ namespace Tomlet.Tests
         [Fact]
         public void DefiningATableArrayWithTheSameNameAsATableThrowsAnException()
         {
-            Assert.Throws<TomlTypeMismatchException>(() => GetDocument(TestResources.DefiningAsArrayWhenAlreadyTableTestInput));
+            Assert.Throws<TomlTableArrayAlreadyExistsAsNonArrayException>(() => GetDocument(TestResources.DefiningAsArrayWhenAlreadyTableTestInput));
         }
 
         [Fact]

--- a/Tomlet.Tests/TomlTableArrayTests.cs
+++ b/Tomlet.Tests/TomlTableArrayTests.cs
@@ -49,13 +49,17 @@ namespace Tomlet.Tests
             //Apple
             var firstFruit = Assert.IsType<TomlTable>(document.GetArray("fruits")[0]);
             Assert.Equal("apple", firstFruit.GetString("name"));
-            
+
             var physical = Assert.IsType<TomlTable>(firstFruit.GetValue("physical"));
+            var jam = Assert.IsType<TomlTable>(firstFruit.GetValue("jam"));
             var varieties = Assert.IsType<TomlArray>(firstFruit.GetValue("varieties"));
             
             Assert.Equal("red", physical.GetString("color"));
             Assert.Equal("round", physical.GetString("shape"));
-            
+
+            Assert.Equal("yellow", jam.GetString("color"));
+            Assert.Equal("sticky", jam.GetString("feel"));
+
             Assert.Equal(2, varieties.Count);
             Assert.Equal("red delicious", Assert.IsType<TomlTable>(varieties[0]).GetString("name"));
             Assert.Equal("granny smith", Assert.IsType<TomlTable>(varieties[1]).GetString("name"));

--- a/Tomlet.Tests/TomlTableArrayTests.cs
+++ b/Tomlet.Tests/TomlTableArrayTests.cs
@@ -67,8 +67,13 @@ namespace Tomlet.Tests
             //Banana
             var secondFruit = Assert.IsType<TomlTable>(document.GetArray("fruits")[1]);
             Assert.Equal("banana", secondFruit.GetString("name"));
-            
+
+            physical = Assert.IsType<TomlTable>(secondFruit.GetValue("physical"));
+            var newtonian = Assert.IsType<TomlTable>(physical.GetValue("newtonian"));
             varieties = Assert.IsType<TomlArray>(secondFruit.GetValue("varieties"));
+
+            Assert.Equal("yellow", physical.GetString("color"));
+            Assert.Equal(118, newtonian.GetInteger("weight"));
 
             Assert.Single(varieties, val => Assert.IsType<TomlTable>(val).GetString("name") == "plantain");
         }

--- a/Tomlet/Models/TomlTable.cs
+++ b/Tomlet/Models/TomlTable.cs
@@ -11,6 +11,7 @@ namespace Tomlet.Models
         public readonly Dictionary<string, TomlValue> Entries = new();
 
         internal bool Locked;
+        internal bool Defined;
 
         public override string StringValue => $"Table ({Entries.Count} entries)";
 

--- a/Tomlet/TomlParser.cs
+++ b/Tomlet/TomlParser.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;

--- a/Tomlet/TomlParser.cs
+++ b/Tomlet/TomlParser.cs
@@ -819,7 +819,12 @@ namespace Tomlet
             TomlArray array;
             if (parentTable.ContainsKey(relativeKey))
             {
-                array = parentTable.GetArray(relativeKey);
+                var value = parentTable.GetValue(relativeKey);
+                if (value is TomlArray arr)
+                    array = arr;
+                else
+                    throw new TomlTableArrayAlreadyExistsAsNonArrayException(_lineNumber, arrayName);
+
                 if (!array.IsLockedToBeTableArray)
                 {
                     throw new TomlNonTableArrayUsedAsTableArrayException(_lineNumber, arrayName);


### PR DESCRIPTION
When the parent table was part of a TableArray, then having multiple subtables was not possible:
```toml
[[SomeArray]]
[SomeArray.SubTable1]
property="SomeValue"
[SomeArray.SubTable2]
property="SomeOtherValue"
```

This happened due to "_lastTableArrayName" being set to null when a sub-table is created.

The proposed change fixes this by storing the full path to both arrays and tables, since both can be nested multiple times. 


The library also errored when a subtable was defined before a parent table: 
```toml
[[SomeArray]]
[SomeArray.SubTable.SubSubTable]
property="SomeValue"
[SomeArray.SubTable]
property="SomeOtherValue"
```

This is valid Toml, which the proposed change also fixes.

The following is invalid Toml and correctly errors, but does not have a test:
```toml
[SomeArray.SubTable]
property="SomeValue"

[[SomeArray]]
property="SomeOtherValue"
```
