### PR TITLE
Attribute mapping added

### DIFF
--- a/Tomlet.Tests/TestModelClasses/ComplexTestRecordWithAttributeMapping.cs
+++ b/Tomlet.Tests/TestModelClasses/ComplexTestRecordWithAttributeMapping.cs
@@ -1,0 +1,15 @@
+﻿namespace Tomlet.Tests.TestModelClasses
+{
+    public record ComplexTestRecordWithAttributeMapping
+    {
+        [TomlProperty("string")]
+        public string MyString { get; init; }
+        public WidgetForThisComplexTestRecordWithAttributeMapping MyWidget { get; init; }
+    }
+
+    public record WidgetForThisComplexTestRecordWithAttributeMapping
+    {
+        [TomlProperty("my_int")]
+        public int MyInt { get; init; }
+    }
+}

--- a/Tomlet.Tests/TestResources.resx
+++ b/Tomlet.Tests/TestResources.resx
@@ -330,4 +330,9 @@ MyDateTime = 1970-01-01T07:00:00</value>
     <data name="LiteralQuotedPathWithBackslashesTestInput" xml:space="preserve">
         <value>Args = '"C:\\Something"'</value>
     </data>
+    <data name="ComplexTestRecordForAttributeMapping" xml:space="preserve">
+        <value>string = "Test"
+[MyWidget]
+my_int = 42</value>
+    </data>
 </root>

--- a/Tomlet.Tests/TomlPropertyMappingTests.cs
+++ b/Tomlet.Tests/TomlPropertyMappingTests.cs
@@ -1,0 +1,26 @@
+using Tomlet.Tests.TestModelClasses;
+using Xunit;
+
+namespace Tomlet.Tests
+{
+    public class TomlPropertyMappingTests
+    {
+        [Fact]
+        public void DeserializationWorks()
+        {
+            var record = TomletMain.To<ComplexTestRecordWithAttributeMapping>(TestResources.ComplexTestRecordForAttributeMapping);
+            Assert.Equal("Test", record.MyString);
+            Assert.IsType<WidgetForThisComplexTestRecordWithAttributeMapping>(record.MyWidget);
+            Assert.Equal(42, record.MyWidget.MyInt);
+        }
+
+        [Fact]
+        public void SerializationWorks()
+        {
+            var testString = TestResources.ComplexTestRecordForAttributeMapping.Trim();
+            var record = TomletMain.To<ComplexTestRecordWithAttributeMapping>(testString);
+            var serialized = TomletMain.TomlStringFrom(record).Trim();
+            Assert.Equal(testString, serialized);
+        }
+    }
+}

--- a/Tomlet/TomlPropertyAttribute.cs
+++ b/Tomlet/TomlPropertyAttribute.cs
@@ -1,0 +1,18 @@
+namespace Tomlet
+{
+    [System.AttributeUsage(System.AttributeTargets.Property)]
+    public class TomlPropertyAttribute : System.Attribute
+    {
+        private readonly string _mapFrom;
+
+        public TomlPropertyAttribute(string mapFrom)
+        {
+            this._mapFrom = mapFrom;
+        }
+
+        public string GetMappedString()
+        {
+            return _mapFrom;
+        }
+    }
+}

--- a/Tomlet/TomlSerializationMethods.cs
+++ b/Tomlet/TomlSerializationMethods.cs
@@ -279,6 +279,9 @@ namespace Tomlet
                         if (m.Success)
                             name = m.Groups[1].Value;
 
+                        var name1 = name;
+                        name = type.GetProperties().FirstOrDefault(p => p.Name == name1)?.GetCustomAttribute<TomlPropertyAttribute>()?.GetMappedString() ?? name;
+                        
                         if (resultTable.ContainsKey(name))
                             //Do not overwrite fields if they have the same name as something already in the table
                             //This fixes serializing types which re-declare a field using the `new` keyword, overwriting a field of the same name

--- a/Tomlet/TomlSerializationMethods.cs
+++ b/Tomlet/TomlSerializationMethods.cs
@@ -187,8 +187,10 @@ namespace Tomlet
                             var name = field.Name;
                             var m = System.Text.RegularExpressions.Regex.Match(field.Name, "<(.*)>k__BackingField");
                             if (m.Success)
-                                name = m.Groups[1].Value; 
+                                name = m.Groups[1].Value;
 
+                            var name1 = name;
+                            name = type.GetProperties().First(p => p.Name == name1).GetCustomAttribute<TomlPropertyAttribute>()?.GetMappedString() ?? name;
                             if (!table.ContainsKey(name))
                                 continue; //TODO: Do we want to make this configurable? As in, throw exception if data is missing?
 

--- a/Tomlet/TomlSerializationMethods.cs
+++ b/Tomlet/TomlSerializationMethods.cs
@@ -190,7 +190,7 @@ namespace Tomlet
                                 name = m.Groups[1].Value;
 
                             var name1 = name;
-                            name = type.GetProperties().First(p => p.Name == name1).GetCustomAttribute<TomlPropertyAttribute>()?.GetMappedString() ?? name;
+                            name = type.GetProperties().FirstOrDefault(p => p.Name == name1)?.GetCustomAttribute<TomlPropertyAttribute>()?.GetMappedString() ?? name;
                             if (!table.ContainsKey(name))
                                 continue; //TODO: Do we want to make this configurable? As in, throw exception if data is missing?
 


### PR DESCRIPTION
Hello,
I wanted to map specific properties. For example a `name = "Something"` should be mapped to `public string Name`. This can be achieved like this:

```toml
[user]
name = "User1"
password = "PW"
``` 
```C#
using Tomlet;
public class Config
{
    [TomlProperty("user")]
    public User User { get; set; }
}

public class User
{
    [TomlProperty("name")]
    public string Name { get; set; }
    [TomlProperty("password")]
    public string Password { get; set; }
} 
```

Currently I made it available under https://www.nuget.org/packages/Wulfheart.Tomlet/2.1.0 until it gets eventually merged.