### PR TITLE
Fixed the Funky Spacing of TomlTable

### DIFF
--- a/Tomlet/Models/TomlTable.cs
+++ b/Tomlet/Models/TomlTable.cs
@@ -94,11 +94,7 @@ namespace Tomlet.Models
             if(keyName != null)
                 keyName = EscapeKeyIfNeeded(keyName);
 
-            var fullSubKey = keyName == null ? subKey : $"{keyName}.{subKey}";
-            
-            if(value is TomlTable {ShouldBeSerializedInline: false} or TomlArray {CanBeSerializedInline: true})
-                //Put a newline before the header on any table array etc
-                builder.Append("\n");
+            var fullSubKey = keyName == null ? subKey : $"{keyName}.{subKey}";  
             
             //Handle any preceding comment - this will ALWAYS go before any sort of value
             if (value.Comments.PrecedingComment != null)


### PR DESCRIPTION
Title speaks for itself.

Before:
![image](https://user-images.githubusercontent.com/8241943/149884136-7048f37e-c121-4eea-adaa-14cb6af20470.png)

After:
![image](https://user-images.githubusercontent.com/8241943/149884174-eb2543e5-d1ff-4bcd-8f0f-b648c71d6c17.png)

