### PR TITLE
Fix exception when parsing blank comments.

### DIFF
--- a/Tomlet.Tests/BasicKeyValueTests.cs
+++ b/Tomlet.Tests/BasicKeyValueTests.cs
@@ -41,14 +41,16 @@ namespace Tomlet.Tests
             
             //Check keys
             Assert.Collection(doc.Entries.Keys,
-                key1 => Assert.Equal("key", key1),
-                key2 => Assert.Equal("another", key2)
+                key1 => Assert.Equal("key1", key1),
+                key2 => Assert.Equal("key2", key2),
+                key3 => Assert.Equal("another", key3)
             );
             
             //Check values
             Assert.Collection(doc.Entries.Values,
-                value1 => Assert.Equal("value", Assert.IsType<TomlString>(value1).Value),
-                value2 => Assert.Equal("# This is not a comment", Assert.IsType<TomlString>(value2).Value)
+                value1 => Assert.Equal("value1", Assert.IsType<TomlString>(value1).Value),
+                value2 => Assert.Equal("value2", Assert.IsType<TomlString>(value2).Value),
+                value3 => Assert.Equal("# This is not a comment", Assert.IsType<TomlString>(value3).Value)
             );
         }
 

--- a/Tomlet.Tests/CommentDeserializationTests.cs
+++ b/Tomlet.Tests/CommentDeserializationTests.cs
@@ -16,8 +16,12 @@ public class CommentDeserializationTests
     {
         var doc = GetDocument(TestResources.CommentTestInput);
 
-        var firstValue = doc.GetValue("key");
-        Assert.Equal("This is a full-line comment", firstValue.Comments.PrecedingComment);
-        Assert.Equal("This is a comment at the end of a line", firstValue.Comments.InlineComment);
+        var firstValue = doc.GetValue("key1");
+        Assert.Null(firstValue.Comments.PrecedingComment);
+        Assert.Null(firstValue.Comments.InlineComment);
+
+        var secondValue = doc.GetValue("key2");
+        Assert.Equal("This is a full-line comment", secondValue.Comments.PrecedingComment);
+        Assert.Equal("This is a comment at the end of a line", secondValue.Comments.InlineComment);
     }
 }

--- a/Tomlet.Tests/CommentSerializationTests.cs
+++ b/Tomlet.Tests/CommentSerializationTests.cs
@@ -51,7 +51,7 @@ public class CommentSerializationTests
 [table] # This is an inline comment
 key = ""value"" # Inline comment on value";
 
-        Assert.Equal(expected, doc.SerializedValue.Trim());
+        Assert.Equal(expected, doc.SerializedValue.Trim().ReplaceLineEndings());
     }
 
     [Fact]
@@ -84,7 +84,7 @@ key = ""value"" # Inline comment on value";
 [[table-array]] # This is an inline comment on the table
 key = ""value"" # Inline comment on value".Trim();
 
-        Assert.Equal(expected, doc.SerializedValue.Trim());
+        Assert.Equal(expected, doc.SerializedValue.Trim().ReplaceLineEndings());
     }
 
     [Fact]
@@ -105,7 +105,7 @@ key = ""value"" # Inline comment on value".Trim();
 ]";
         
         //Replace tabs with spaces because this source file uses spaces
-        var actual = doc.SerializedValue.Trim().Replace("\t", "    ");
+        var actual = doc.SerializedValue.Trim().Replace("\t", "    ").ReplaceLineEndings();
         Assert.Equal(expected, actual);
     }
 

--- a/Tomlet.Tests/TestResources.Designer.cs
+++ b/Tomlet.Tests/TestResources.Designer.cs
@@ -168,8 +168,10 @@ namespace Tomlet.Tests {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to # This is a full-line comment
-        ///key = &quot;value&quot;  # This is a comment at the end of a line
+        ///   Looks up a localized string similar to #
+        ///key1 = &quot;value1&quot;  #
+        ///# This is a full-line comment
+        ///key2 = &quot;value2&quot;  # This is a comment at the end of a line
         ///another = &quot;# This is not a comment&quot;.
         /// </summary>
         internal static string CommentTestInput {

--- a/Tomlet.Tests/TestResources.resx
+++ b/Tomlet.Tests/TestResources.resx
@@ -19,8 +19,10 @@
         <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
     </resheader>
     <data name="CommentTestInput" xml:space="preserve">
-        <value># This is a full-line comment
-key = "value"  # This is a comment at the end of a line
+    <value>#
+key1 = "value1"  #
+# This is a full-line comment
+key2 = "value2"  # This is a comment at the end of a line
 another = "# This is not a comment"</value>
     </data>
     <data name="BasicKVPTestInput" xml:space="preserve">

--- a/Tomlet.Tests/TomlTableArrayTests.cs
+++ b/Tomlet.Tests/TomlTableArrayTests.cs
@@ -96,7 +96,7 @@ namespace Tomlet.Tests
                 array
             };
             
-            var tomlString = TomletMain.TomlStringFrom(documentRoot).Trim();
+            var tomlString = TomletMain.TomlStringFrom(documentRoot).Trim().ReplaceLineEndings();
 
             var expectedResult = @"
 [[array]]
@@ -146,7 +146,7 @@ B = ""B""
 
 [[Root.Array]]
 A = ""C""
-B = ""D""", str.Trim());
+B = ""D""", str.Trim().ReplaceLineEndings());
         }
     }
 }

--- a/Tomlet/TomlParser.cs
+++ b/Tomlet/TomlParser.cs
@@ -998,7 +998,7 @@ namespace Tomlet
             {
                 var line = reader.ReadWhile(c => !c.IsNewline());
                 
-                if(line[0] == ' ')
+                if(line.Length > 0 && line[0] == ' ')
                     line = line.Substring(1);
                 
                 foreach (var i in line.Select(c => (int) c)) 


### PR DESCRIPTION
* Fix an array out-of-bounds bug when parsing blank preceding comments. (`#`)
* Fix the problem that the test fails under Windows due to the mismatch of line ending.