### PR TITLE
Add better constructor support for deserialization

### DIFF
--- a/Tomlet.Tests/ClassDeserializationTests.cs
+++ b/Tomlet.Tests/ClassDeserializationTests.cs
@@ -55,6 +55,14 @@ namespace Tomlet.Tests
         }
 
         [Fact]
+        public void ClassWithParameterlessConstructorDeserializationWorks()
+        {
+            var type = TomletMain.To<ClassWithParameterlessConstructor>(TestResources.SimplePrimitiveDeserializationTestInput);
+            
+            Assert.Equal("Hello, world!", type.MyString);
+        }
+        
+        [Fact]
         public void AnArrayOfEmptyStringsCanBeDeserialized()
         {
             var wrapper = TomletMain.To<StringArrayWrapper>(TestResources.ArrayOfEmptyStringTestInput);
@@ -74,6 +82,24 @@ namespace Tomlet.Tests
 
             var msg = $"While deserializing an object of type {typeof(SimplePrimitiveTestClass).FullName}, found field MyFloat expecting a type of Double, but value in TOML was of type String";
             Assert.Equal(msg, ex.Message);
+        }
+
+        [Fact]
+        public void ShouldOverrideDefaultConstructorsValues()
+        {
+            var options = new TomlSerializerOptions { OverrideConstructorValues = true };
+            var type = TomletMain.To<ClassWithValuesSetOnConstructor>(TestResources.SimplePrimitiveDeserializationTestInput, options);
+            
+            Assert.Equal("Hello, world!", type.MyString);
+        }
+        
+        [Fact]
+        public void ShouldNotOverrideDefaultConstructorsValues()
+        {
+            var options = new TomlSerializerOptions { OverrideConstructorValues = false };
+            var type = TomletMain.To<ClassWithValuesSetOnConstructor>(TestResources.SimplePrimitiveDeserializationTestInput, options);
+            
+            Assert.Equal("Modified on constructor!", type.MyString);
         }
     }
 }

--- a/Tomlet.Tests/ClassWithValuesSetOnConstructor.cs
+++ b/Tomlet.Tests/ClassWithValuesSetOnConstructor.cs
@@ -1,0 +1,11 @@
+﻿namespace Tomlet.Tests;
+
+public class ClassWithValuesSetOnConstructor
+{
+    public ClassWithValuesSetOnConstructor(string myString)
+    {
+        MyString = "Modified on constructor!";
+    }
+
+    public string MyString { get; set; }
+}

--- a/Tomlet.Tests/ExceptionTests.cs
+++ b/Tomlet.Tests/ExceptionTests.cs
@@ -190,6 +190,14 @@ public class ExceptionTests
     [Fact]
     public void UnInstantiableObjectsThrow() => 
         AssertThrows<TomlInstantiationException>(() => TomletMain.To<IConvertible>(""));
+
+    [Fact]
+    public void MultipleParameterizedConstructorsThrow() =>
+        AssertThrows<TomlInstantiationException>(() => TomletMain.To<ClassWithMultipleParameterizedConstructors>(""));
+    
+    [Fact]
+    public void AbstractClassDeserializationThrows() =>
+        AssertThrows<TomlInstantiationException>(() => TomletMain.To<AbstractClass>(""));
     
     [Fact]
     public void MismatchingTypesInPrimitiveMappingThrows() => 

--- a/Tomlet.Tests/ObjectToStringTests.cs
+++ b/Tomlet.Tests/ObjectToStringTests.cs
@@ -77,34 +77,23 @@ namespace Tomlet.Tests
         [Fact]
         public void SerializingSimpleTestRecordToTomlStringWorks()
         {
-            var testObject = new SimpleTestRecord
-            {
-                MyBool = true,
-                MyFloat = 420.69f,
-                MyString = "Hello, world!",
-                MyDateTime = new DateTime(1970, 1, 1, 7, 0, 0, DateTimeKind.Utc)
-            };
-
+            var testObject = new SimpleTestRecord("Hello, world!", 420.69f, true,
+                new DateTime(1970, 1, 1, 7, 0, 0, DateTimeKind.Utc));
             var serializedForm = TomletMain.TomlStringFrom(testObject);
-
+        
             Assert.Equal("MyString = \"Hello, world!\"\nMyFloat = 420.69000244140625\nMyBool = true\nMyDateTime = 1970-01-01T07:00:00", serializedForm.Trim());
         }
 
         [Fact]
         public void SerializingSimpleTestRecordAndDeserializingAgainGivesEquivalentObject()
         {
-            var testObject = new SimpleTestRecord
-            {
-                MyBool = true,
-                MyFloat = 420.69f,
-                MyString = "Hello, world!",
-                MyDateTime = new DateTime(1970, 1, 1, 7, 0, 0, DateTimeKind.Utc)
-            };
+            var testObject = new SimpleTestRecord("Hello, world!", 420.69f, true,
+                new DateTime(1970, 1, 1, 7, 0, 0, DateTimeKind.Utc));
 
             var serializedForm = TomletMain.TomlStringFrom(testObject);
-
+        
             var deserializedAgain = TomletMain.To<SimpleTestRecord>(serializedForm);
-
+        
             Assert.Equal(testObject, deserializedAgain);
         }
 
@@ -120,7 +109,7 @@ namespace Tomlet.Tests
         public void AttemptingToDirectlySerializeNullThrows()
         {
             //We need to use a type of T that actually has something to serialize
-            Assert.Throws<ArgumentNullException>(() => TomletMain.DocumentFrom(typeof(SimplePrimitiveTestClass), null!));
+            Assert.Throws<ArgumentNullException>(() => TomletMain.DocumentFrom(typeof(SimplePrimitiveTestClass), null!, null));
         }
     }
 }

--- a/Tomlet.Tests/ObjectToTomlDocTests.cs
+++ b/Tomlet.Tests/ObjectToTomlDocTests.cs
@@ -66,20 +66,15 @@ NotOverwrittenSuperclassField = ""this is a non-overwritten field, defined only 
             Assert.Equal("Hello, world!", tomlDoc.GetString("MyString"));
             Assert.Equal("1970-01-01T07:00:00", tomlDoc.GetValue("MyDateTime").StringValue);
         }
-
+        
         [Fact]
         public void SimpleTestRecordToTomlDocWorks()
         {
-            var testObject = new SimpleTestRecord
-            {
-                MyBool = true,
-                MyFloat = 420.69f,
-                MyString = "Hello, world!",
-                MyDateTime = new DateTime(1970, 1, 1, 7, 0, 0, DateTimeKind.Utc)
-            };
+            var testObject = new SimpleTestRecord("Hello, world!", 420.69f, true,
+                new DateTime(1970, 1, 1, 7, 0, 0, DateTimeKind.Utc));
 
             var tomlDoc = TomletMain.DocumentFrom(testObject);
-
+        
             Assert.Equal(4, tomlDoc.Entries.Count);
             Assert.True(tomlDoc.GetBoolean("MyBool"));
             Assert.True(Math.Abs(tomlDoc.GetFloat("MyFloat") - 420.69) < 0.01);

--- a/Tomlet.Tests/TestModelClasses/AbstractClass.cs
+++ b/Tomlet.Tests/TestModelClasses/AbstractClass.cs
@@ -1,0 +1,6 @@
+﻿namespace Tomlet.Tests.TestModelClasses;
+
+public abstract class AbstractClass
+{
+    
+}

--- a/Tomlet.Tests/TestModelClasses/ClassWithMultipleParameterizedConstructors.cs
+++ b/Tomlet.Tests/TestModelClasses/ClassWithMultipleParameterizedConstructors.cs
@@ -1,0 +1,16 @@
+﻿namespace Tomlet.Tests.TestModelClasses;
+
+public class ClassWithMultipleParameterizedConstructors
+{
+    public ClassWithMultipleParameterizedConstructors(string myString)
+    {
+        MyString = myString;
+    }
+    
+    public ClassWithMultipleParameterizedConstructors(string myString, int age)
+    {
+        MyString = myString;
+    }
+    
+    public string MyString { get; set; }
+}

--- a/Tomlet.Tests/TestModelClasses/ClassWithParameterlessConstructor.cs
+++ b/Tomlet.Tests/TestModelClasses/ClassWithParameterlessConstructor.cs
@@ -1,0 +1,9 @@
+﻿namespace Tomlet.Tests.TestModelClasses;
+
+public class ClassWithParameterlessConstructor : ClassWithMultipleParameterizedConstructors
+{
+    public ClassWithParameterlessConstructor() : base(string.Empty, int.MinValue)
+    {
+        
+    }
+}

--- a/Tomlet.Tests/TestModelClasses/SimpleTestRecord.cs
+++ b/Tomlet.Tests/TestModelClasses/SimpleTestRecord.cs
@@ -1,12 +1,5 @@
 ﻿using System;
 
-namespace Tomlet.Tests.TestModelClasses
-{
-    public record SimpleTestRecord
-    {
-        public string MyString { get; init; }
-        public float MyFloat { get; init; }
-        public bool MyBool { get; init; }
-        public DateTime MyDateTime { get; init; }
-    }
-}
+namespace Tomlet.Tests.TestModelClasses;
+
+public record SimpleTestRecord(string MyString, float MyFloat, bool MyBool, DateTime MyDateTime);

--- a/Tomlet/Exceptions/TomlInstantiationException.cs
+++ b/Tomlet/Exceptions/TomlInstantiationException.cs
@@ -1,16 +1,8 @@
-﻿using System;
-
-namespace Tomlet.Exceptions
+﻿namespace Tomlet.Exceptions
 {
     public class TomlInstantiationException : TomlException
     {
-        private readonly Type _type;
-
-        public TomlInstantiationException(Type type)
-        {
-            _type = type;
-        }
-
-        public override string Message => $"Could not find a no-argument constructor for type {_type.FullName}";
+        public override string Message =>
+            "Deserialization of types without a parameterless constructor or a singular parameterized constructor is not supported.";
     }
 }

--- a/Tomlet/Exceptions/TomlParameterTypeMismatchException.cs
+++ b/Tomlet/Exceptions/TomlParameterTypeMismatchException.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Reflection;
+
+namespace Tomlet.Exceptions
+{
+    public class TomlParameterTypeMismatchException : TomlTypeMismatchException
+    {
+        private readonly Type _typeBeingInstantiated;
+        private readonly ParameterInfo _paramBeingDeserialized;
+
+        public TomlParameterTypeMismatchException(Type typeBeingInstantiated, ParameterInfo paramBeingDeserialized, TomlTypeMismatchException cause) : base(cause.ExpectedType, cause.ActualType, paramBeingDeserialized.ParameterType)
+        {
+            _typeBeingInstantiated = typeBeingInstantiated;
+            _paramBeingDeserialized = paramBeingDeserialized;
+        }
+
+        public override string Message => $"While deserializing an object of type {_typeBeingInstantiated}, found parameter {_paramBeingDeserialized.Name} expecting a type of {ExpectedTypeName}, but value in TOML was of type {ActualTypeName}";
+    }
+}

--- a/Tomlet/Extensions/GenericExtensions.cs
+++ b/Tomlet/Extensions/GenericExtensions.cs
@@ -6,9 +6,9 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using Tomlet.Exceptions;
 
-namespace Tomlet
+namespace Tomlet.Extensions
 {
-    internal static class Extensions
+    internal static class GenericExtensions
     {
         private static readonly HashSet<int> IllegalChars = new()
         {

--- a/Tomlet/Extensions/ReflectionExtensions.cs
+++ b/Tomlet/Extensions/ReflectionExtensions.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+
+namespace Tomlet.Extensions
+{
+    internal static class ReflectionExtensions
+    {
+        internal static bool TryGetBestMatchConstructor(this Type type, out ConstructorInfo? bestMatchConstructor)
+        {
+            var constructors = type.GetConstructors(BindingFlags.Public | BindingFlags.Instance);
+            if (constructors.Length == 0)
+            {
+                bestMatchConstructor = null;
+                return false;
+            }
+
+            var parameterlessConstructor = constructors.FirstOrDefault(c => c.GetParameters().Length == 0);
+            if (parameterlessConstructor != null)
+            {
+                bestMatchConstructor = parameterlessConstructor;
+                return true;
+            }
+
+            var parameterizedConstructors = constructors.Where(c => c.GetParameters().Length > 0).ToArray();
+            if (parameterizedConstructors.Length > 1)
+            {
+                bestMatchConstructor = null;
+                return false;
+            }
+
+            bestMatchConstructor = parameterizedConstructors.Single();
+            return true;
+        }
+    }
+}

--- a/Tomlet/Extensions/StringExtensions.cs
+++ b/Tomlet/Extensions/StringExtensions.cs
@@ -1,0 +1,24 @@
+﻿using System.Text;
+
+namespace Tomlet.Extensions
+{
+    internal static class StringExtensions
+    {
+        internal static string ToPascalCase(this string str)
+        {
+            var sb = new StringBuilder(str.Length);
+
+            if (str.Length > 0)
+            {
+                sb.Append(char.ToUpper(str[0]));
+            }
+
+            for (var i = 1; i < str.Length; i++)
+            {
+                sb.Append(char.IsWhiteSpace(str[i - 1]) ? char.ToUpper(str[i]) : str[i]);
+            }
+
+            return sb.ToString();
+        }
+    }
+}

--- a/Tomlet/Models/TomlString.cs
+++ b/Tomlet/Models/TomlString.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Tomlet.Extensions;
 
 namespace Tomlet.Models
 {

--- a/Tomlet/Models/TomlTable.cs
+++ b/Tomlet/Models/TomlTable.cs
@@ -1,10 +1,11 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using Tomlet.Exceptions;
+using Tomlet.Extensions;
 
 namespace Tomlet.Models
 {

--- a/Tomlet/TomlDateTimeUtils.cs
+++ b/Tomlet/TomlDateTimeUtils.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text.RegularExpressions;
 using Tomlet.Exceptions;
+using Tomlet.Extensions;
 using Tomlet.Models;
 
 namespace Tomlet

--- a/Tomlet/TomlNumberUtils.cs
+++ b/Tomlet/TomlNumberUtils.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using System.Linq;
+using Tomlet.Extensions;
 
 namespace Tomlet
 {

--- a/Tomlet/TomlParser.cs
+++ b/Tomlet/TomlParser.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using Tomlet.Attributes;
 using Tomlet.Exceptions;
+using Tomlet.Extensions;
 using Tomlet.Models;
 
 namespace Tomlet

--- a/Tomlet/TomlSerializerOptions.cs
+++ b/Tomlet/TomlSerializerOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace Tomlet
+{
+    public class TomlSerializerOptions
+    {
+        public static TomlSerializerOptions Default = new();
+        public bool OverrideConstructorValues { get; set; } = false;
+    }
+}

--- a/Tomlet/TomletMain.cs
+++ b/Tomlet/TomletMain.cs
@@ -1,6 +1,5 @@
-﻿using System;
+using System;
 using System.Diagnostics.CodeAnalysis;
-using Tomlet.Attributes;
 using Tomlet.Exceptions;
 using Tomlet.Models;
 
@@ -15,22 +14,22 @@ namespace Tomlet
         public static void RegisterMapper<T>(TomlSerializationMethods.Serialize<T>? serializer, TomlSerializationMethods.Deserialize<T>? deserializer)
             => TomlSerializationMethods.Register(serializer, deserializer);
 
-        public static T To<T>(string tomlString)
+        public static T To<T>(string tomlString, TomlSerializerOptions? options = null)
         {
             var parser = new TomlParser();
             var tomlDocument = parser.Parse(tomlString);
 
-            return To<T>(tomlDocument);
+            return To<T>(tomlDocument, options);
         }
 
-        public static T To<T>(TomlValue value)
+        public static T To<T>(TomlValue value, TomlSerializerOptions? options = null)
         {
-            return (T)To(typeof(T), value);
+            return (T)To(typeof(T), value, options);
         }
 
-        public static object To(Type what, TomlValue value)
+        public static object To(Type what, TomlValue value, TomlSerializerOptions? options = null)
         {
-            var deserializer = TomlSerializationMethods.GetDeserializer(what);
+            var deserializer = TomlSerializationMethods.GetDeserializer(what, options);
 
             return deserializer.Invoke(value);
         }
@@ -38,37 +37,37 @@ namespace Tomlet
 #if NET6_0
         [return: NotNullIfNotNull("t")]
 #endif
-        public static TomlValue? ValueFrom<T>(T t)
+        public static TomlValue? ValueFrom<T>(T t, TomlSerializerOptions? options = null)
         {
             if (t == null)
                 throw new ArgumentNullException(nameof(t));
 
-            return ValueFrom(t.GetType(), t);
+            return ValueFrom(t.GetType(), t, options);
         }
 
 #if NET6_0
         [return: NotNullIfNotNull("t")]
 #endif
-        public static TomlValue? ValueFrom(Type type, object t)
+        public static TomlValue? ValueFrom(Type type, object t, TomlSerializerOptions? options = null)
         {
-            var serializer = TomlSerializationMethods.GetSerializer(type);
+            var serializer = TomlSerializationMethods.GetSerializer(type, options);
 
             var tomlValue = serializer.Invoke(t);
 
             return tomlValue!;
         }
 
-        public static TomlDocument DocumentFrom<T>(T t)
+        public static TomlDocument DocumentFrom<T>(T t, TomlSerializerOptions? options = null)
         {
             if (t == null)
                 throw new ArgumentNullException(nameof(t));
 
-            return DocumentFrom(t.GetType(), t);
+            return DocumentFrom(t.GetType(), t, options);
         }
 
-        public static TomlDocument DocumentFrom(Type type, object t)
+        public static TomlDocument DocumentFrom(Type type, object t, TomlSerializerOptions? options = null)
         {
-            var val = ValueFrom(type, t);
+            var val = ValueFrom(type, t, options);
 
             return val switch
             {
@@ -78,8 +77,8 @@ namespace Tomlet
             };
         }
 
-        public static string TomlStringFrom<T>(T t) => DocumentFrom(t).SerializedValue;
+        public static string TomlStringFrom<T>(T t, TomlSerializerOptions? options = null) => DocumentFrom(t, options).SerializedValue;
 
-        public static string TomlStringFrom(Type type, object t) => DocumentFrom(type, t).SerializedValue;
+        public static string TomlStringFrom(Type type, object t, TomlSerializerOptions? options = null) => DocumentFrom(type, t, options).SerializedValue;
     }
 }


### PR DESCRIPTION
The behaviour in the mechanism is based on the behaviour observed on the System.Text.Json library, when attempting to deserialize JSON strings.

- Introduced a mechanism for dynamically identifying and invoking the most suitable constructor for a given type, making it able to call any constructor with `N` parameters. This specially useful when dealing with records. Because most people declare records as following: `record MyRecord(string MyString, ...)`
- If there are matching keys between the TOML string and the constructor's parameters, it initializes the properties from the parameters.
- Introduced a `TomlSerializerOptions` class with an `OverrideConstructorValues` option.

if there is anything wrong with it, let me know or feel free to change it yourself.