### PR TITLE
Add option to ignore non-public members when de/serializing

### DIFF
--- a/Tomlet/TomlCompositeDeserializer.cs
+++ b/Tomlet/TomlCompositeDeserializer.cs
@@ -35,12 +35,17 @@ internal static class TomlCompositeDeserializer
         else
         {
             //Get all instance fields
-            var fields = type.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            var memberFlags = BindingFlags.Public | BindingFlags.Instance;
+            if (!options.IgnoreNonPublicMembers) {
+                memberFlags |= BindingFlags.NonPublic;
+            }
+
+            var fields = type.GetFields(memberFlags);
 
             //Ignore NonSerialized and CompilerGenerated fields.
             fields = fields.Where(f => !f.IsNotSerialized && GenericExtensions.GetCustomAttribute<CompilerGeneratedAttribute>(f) == null).ToArray();
 
-            var props = type.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            var props = type.GetProperties(memberFlags);
 
             //Ignore TomlNonSerializedAttribute Decorated Properties
             var propsDict = props

--- a/Tomlet/TomlCompositeSerializer.cs
+++ b/Tomlet/TomlCompositeSerializer.cs
@@ -22,10 +22,15 @@ internal static class TomlCompositeSerializer
         else
         {
             //Get all instance fields
-            var fields = type.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            var memberFlags = BindingFlags.Public | BindingFlags.Instance;
+            if (!options.IgnoreNonPublicMembers) {
+                memberFlags |= BindingFlags.NonPublic;
+            }
+
+            var fields = type.GetFields(memberFlags);
             var fieldAttribs = fields
                 .ToDictionary(f => f, f => new {inline = GenericExtensions.GetCustomAttribute<TomlInlineCommentAttribute>(f), preceding = GenericExtensions.GetCustomAttribute<TomlPrecedingCommentAttribute>(f), noInline = GenericExtensions.GetCustomAttribute<TomlDoNotInlineObjectAttribute>(f)});
-            var props = type.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+            var props = type.GetProperties(memberFlags)
                 .ToArray();
             var propAttribs = props
                 .ToDictionary(p => p, p => new {inline = GenericExtensions.GetCustomAttribute<TomlInlineCommentAttribute>(p), preceding = GenericExtensions.GetCustomAttribute<TomlPrecedingCommentAttribute>(p), prop = GenericExtensions.GetCustomAttribute<TomlPropertyAttribute>(p), noInline = GenericExtensions.GetCustomAttribute<TomlDoNotInlineObjectAttribute>(p)});

--- a/Tomlet/TomlSerializerOptions.cs
+++ b/Tomlet/TomlSerializerOptions.cs
@@ -4,5 +4,6 @@
     {
         public static TomlSerializerOptions Default = new();
         public bool OverrideConstructorValues { get; set; } = false;
+        public bool IgnoreNonPublicMembers { get; set; } = false;
     }
 }


### PR DESCRIPTION
Off by default, of course