### PR TITLE
Implement deserialization of dictionaries using primitives as keys

### DIFF
--- a/Tomlet/Extensions/ReflectionExtensions.cs
+++ b/Tomlet/Extensions/ReflectionExtensions.cs
@@ -32,5 +32,22 @@ namespace Tomlet.Extensions
             bestMatchConstructor = parameterizedConstructors.Single();
             return true;
         }
+
+        internal static bool IsIntegerType(this Type type) {
+            switch (Type.GetTypeCode(type)) {
+                case TypeCode.Byte:
+                case TypeCode.SByte:
+                case TypeCode.UInt16:
+                case TypeCode.Int16:
+                case TypeCode.UInt32:
+                case TypeCode.Int32:
+                case TypeCode.UInt64:
+                case TypeCode.Int64:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
     }
 }

--- a/Tomlet/TomlSerializationMethods.cs
+++ b/Tomlet/TomlSerializationMethods.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Reflection;
 using Tomlet.Attributes;
 using Tomlet.Exceptions;
+using Tomlet.Extensions;
 using Tomlet.Models;
 
 namespace Tomlet
@@ -198,9 +199,10 @@ namespace Tomlet
                     return (Deserialize<object>)_stringKeyedDictionaryMethod.MakeGenericMethod(genericArgs[1]).Invoke(null, new object[]{options})!;
                 }
 
-                if (genericArgs[0].IsPrimitive && typeof(IConvertible).IsAssignableFrom(genericArgs[0]))
+                if (genericArgs[0].IsIntegerType() || genericArgs[0] == typeof(bool) || genericArgs[0] == typeof(char))
                 {
-                    return (Deserialize<object>)_primitiveKeyedDictionaryMethod.MakeGenericMethod(genericArgs[0], genericArgs[1]).Invoke(null, new object[]{options})!;
+                    // float primitives not supported due to decimal point causing issues
+                    return (Deserialize<object>)_primitiveKeyedDictionaryMethod.MakeGenericMethod(genericArgs).Invoke(null, new object[]{options})!;
                 }
             }
 


### PR DESCRIPTION
Previously only worked with strings and would fail quietly if anything else was used (at least on net8.0, haven't checked other targets)