### PR TITLE
Support for Runtime types in DocumentFrom<T>

### DIFF
--- a/Tomlet.Tests/ObjectToStringTests.cs
+++ b/Tomlet.Tests/ObjectToStringTests.cs
@@ -111,5 +111,20 @@ namespace Tomlet.Tests
             //We need to use a type of T that actually has something to serialize
             Assert.Null(TomletMain.DocumentFrom(typeof(SimplePrimitiveTestClass), null!, null));
         }
+
+        [Fact]
+        public void SerializingAbstractObjectToStringWorks()
+        {
+            var testObject = new InheritedClass
+            {
+                MyBool = true,
+                MyFloat = 420.69f,
+                MyString = "Hello, world!",
+                MyDateTime = new DateTime(1970, 1, 1, 7, 0, 0, DateTimeKind.Utc)
+            };
+
+            var serializedForm = TomletMain.TomlStringFrom((AbstractClass)testObject);
+            Assert.Equal("MyString = \"Hello, world!\"\nMyFloat = 420.69000244140625\nMyBool = true\nMyDateTime = 1970-01-01T07:00:00", serializedForm.Trim());
+        }
     }
 }

--- a/Tomlet.Tests/TestModelClasses/InheritedClass.cs
+++ b/Tomlet.Tests/TestModelClasses/InheritedClass.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Tomlet.Tests.TestModelClasses;
+
+public class InheritedClass : AbstractClass
+{
+    public string MyString;
+    public float MyFloat;
+    public bool MyBool;
+    public DateTime MyDateTime;
+}

--- a/Tomlet/TomletMain.cs
+++ b/Tomlet/TomletMain.cs
@@ -116,8 +116,7 @@ public static class TomletMain
     {
         if (t == null)
             return null;
-
-        return DocumentFrom(typeof(T), t, options);
+        return DocumentFrom(t.GetType(), t, options);
     }
 
 #if MODERN_DOTNET

--- a/Tomlet/TomletMain.cs
+++ b/Tomlet/TomletMain.cs
@@ -116,6 +116,7 @@ public static class TomletMain
     {
         if (t == null)
             return null;
+        
         return DocumentFrom(t.GetType(), t, options);
     }
 


### PR DESCRIPTION
Currently DocumentFrom<T> gets the type from `typeof()` and with the test below, it would return the abstract class `AbstractClass`. This is because typeof is for compile time. 

Using `.GetType()` calls it on that instance, which in the test returns `InheritedClass` and then the rest can continue as normal.


# Why

I have a Unity mod loader, where I was planning on people creating their own classes which inheritied off `BaseSettings` which is abstract. I realised that as I didn't know their types at compile time, when I passed `this` into `TomletMain.TomlStringFrom(this);` it would not save and load my properties.