### PR TITLE
feat: Add support for TomlFieldAttribute (#54)

### DIFF
--- a/Tomlet/Attributes/TomlFieldAttribute.cs
+++ b/Tomlet/Attributes/TomlFieldAttribute.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace Tomlet.Attributes;
+
+[AttributeUsage(AttributeTargets.Field)]
+public class TomlFieldAttribute : Attribute
+{
+    private readonly string _mapFrom;
+
+    public TomlFieldAttribute(string mapFrom)
+    {
+        _mapFrom = mapFrom;
+    }
+
+    public string GetMappedString()
+    {
+        return _mapFrom;
+    }
+}

--- a/Tomlet/TomlCompositeSerializer.cs
+++ b/Tomlet/TomlCompositeSerializer.cs
@@ -35,7 +35,7 @@ internal static class TomlCompositeSerializer
 
             var fields = type.GetFields(memberFlags);
             var fieldAttribs = fields
-                .ToDictionary(f => f, f => new {inline = GenericExtensions.GetCustomAttribute<TomlInlineCommentAttribute>(f), preceding = GenericExtensions.GetCustomAttribute<TomlPrecedingCommentAttribute>(f), noInline = GenericExtensions.GetCustomAttribute<TomlDoNotInlineObjectAttribute>(f)});
+                .ToDictionary(f => f, f => new {inline = GenericExtensions.GetCustomAttribute<TomlInlineCommentAttribute>(f), preceding = GenericExtensions.GetCustomAttribute<TomlPrecedingCommentAttribute>(f), field = GenericExtensions.GetCustomAttribute<TomlFieldAttribute>(f), noInline = GenericExtensions.GetCustomAttribute<TomlDoNotInlineObjectAttribute>(f)});
             var props = type.GetProperties(memberFlags)
                 .ToArray();
             var propAttribs = props
@@ -73,7 +73,7 @@ internal static class TomlCompositeSerializer
                     if(tomlValue == null)
                         continue;
                     
-                    var commentAttribs = fieldAttribs[field];
+                    var thisFieldAttribs = fieldAttribs[field];
 
                     if (resultTable.ContainsKey(field.Name))
                         //Do not overwrite fields if they have the same name as something already in the table
@@ -81,13 +81,13 @@ internal static class TomlCompositeSerializer
                         //in its supertype. 
                         continue;
 
-                    tomlValue.Comments.InlineComment = commentAttribs.inline?.Comment;
-                    tomlValue.Comments.PrecedingComment = commentAttribs.preceding?.Comment;
+                    tomlValue.Comments.InlineComment = thisFieldAttribs.inline?.Comment;
+                    tomlValue.Comments.PrecedingComment = thisFieldAttribs.preceding?.Comment;
                     
-                    if(commentAttribs.noInline != null && tomlValue is TomlTable table)
+                    if(thisFieldAttribs.noInline != null && tomlValue is TomlTable table)
                         table.ForceNoInline = true;
 
-                    resultTable.PutValue(field.Name, tomlValue);
+                    resultTable.PutValue(thisFieldAttribs.field?.GetMappedString() ?? field.Name, tomlValue);
                 }
 
                 foreach (var prop in props)


### PR DESCRIPTION
Added a new TomlFieldAttribute
Updated TomlCompositeSerializer/TomlCompositeDeserializer to work with TomlFieldAttribute

Example usage:

Before:
```
[TomlDoNotInlineObject]
public class GameSettings
{
    public enum DisplayMode
    {
        Windowed = 0,
        Fullscreen = 1,
    }
    
    [TomlProperty("display.mode")]
    public DisplayMode ScreenDisplayMode { get; set; } = DisplayMode.Fullscreen;
}
// ...
var mode = _temporary.ScreenDisplayMode;
if (
    ImGuiHelper.DrawCombo(
        GameStrings.Mode,
        ref mode,
        EnumCollections.DisplayModes,
        mode != Current.ScreenDisplayMode
    )
)
    _temporary.ScreenDisplayMode = mode;
```

After:
```
[TomlDoNotInlineObject]
public class GameSettings
{
    public enum DisplayMode
    {
        Windowed = 0,
        Fullscreen = 1,
    }
    
    [TomlField("display.mode")]
    public DisplayMode ScreenDisplayMode = DisplayMode.Fullscreen;
}
// ...
ImGuiHelper.DrawCombo(
    GameStrings.Mode,
    ref _temporary.ScreenDisplayMode,
    EnumCollections.DisplayModes,
    _temporary.ScreenDisplayMode != Current.ScreenDisplayMode
);
```
