### PR TITLE
Fix potential crash when deserializing Dictionary<T, U> where T is an enum

### DIFF
--- a/Tomlet.Tests/DeliberatelyIncorrectTestResources.Designer.cs
+++ b/Tomlet.Tests/DeliberatelyIncorrectTestResources.Designer.cs
@@ -141,6 +141,12 @@ namespace Tomlet.Tests {
             }
         }
         
+        internal static string EnumKeyRedefinitionViaTableTestInput {
+            get {
+                return ResourceManager.GetString("EnumKeyRedefinitionViaTableTestInput", resourceCulture);
+            }
+        }
+        
         internal static string ReDefiningSubTableAsSubTableArrayTestInput {
             get {
                 return ResourceManager.GetString("ReDefiningSubTableAsSubTableArrayTestInput", resourceCulture);

--- a/Tomlet.Tests/DeliberatelyIncorrectTestResources.resx
+++ b/Tomlet.Tests/DeliberatelyIncorrectTestResources.resx
@@ -82,6 +82,15 @@ apple = "red"
 [fruit.apple]
 texture = "smooth"</value>
     </data>
+    <data name="EnumKeyRedefinitionViaTableTestInput" xml:space="preserve">
+        <value>[Subnames]
+[Subnames.Value1]
+a = 'A'
+b = 'B'
+[Subnames.Value1]
+a = 'A'
+b = 'B'</value>
+    </data>
     <data name="ReDefiningSubTableAsSubTableArrayTestInput" xml:space="preserve">
         <value># INVALID TOML DOC
 [[fruits]]

--- a/Tomlet.Tests/EnumTests.cs
+++ b/Tomlet.Tests/EnumTests.cs
@@ -64,7 +64,16 @@ public class EnumTests
         var expected = new Dictionary<TestEnum, int> {{TestEnum.Value1, 1}, {TestEnum.Value2, 2}, {TestEnum.Value3, 3}};
         Assert.Equal(expected, result);
     }
-
+    
+    [Fact]
+    public void CanIgnoreInvalidEnumDictionaryKeys()
+    {
+        var toml = "Value1 = 1\nValue2 = 2\nValue3 = 3\nValue4 = 4\nValue5 = 5\nValue6 = 6\n";
+        var result = TomletMain.To<Dictionary<TestEnum, int>>(toml, new TomlSerializerOptions { IgnoreInvalidEnumValues = true });
+        var expected = new Dictionary<TestEnum, int> {{TestEnum.Value1, 1}, {TestEnum.Value2, 2}, {TestEnum.Value3, 3}};
+        Assert.Equal(expected, result);
+    }
+    
     [Fact]
     public void CanDeserializeEnumDictionaryWithFields()
     {

--- a/Tomlet.Tests/ExceptionTests.cs
+++ b/Tomlet.Tests/ExceptionTests.cs
@@ -110,6 +110,10 @@ public class ExceptionTests
         AssertThrows<TomlKeyRedefinitionException>(() => GetDocument(DeliberatelyIncorrectTestResources.KeyRedefinitionViaTableTestInput));
     
     [Fact]
+    public void RedefiningAnEnumKeyAsATableEntryThrowsAnException() => 
+        AssertThrows<TomlTableRedefinitionException>(() => GetDocument(DeliberatelyIncorrectTestResources.EnumKeyRedefinitionViaTableTestInput));
+    
+    [Fact]
     public void DefiningATableArrayWithTheSameNameAsATableThrowsAnException() => 
         AssertThrows<TomlTableArrayAlreadyExistsAsNonArrayException>(() => GetDocument(DeliberatelyIncorrectTestResources.DefiningAsArrayWhenAlreadyTableTestInput));
 

--- a/Tomlet/TomlSerializerOptions.cs
+++ b/Tomlet/TomlSerializerOptions.cs
@@ -17,5 +17,8 @@ public class TomlSerializerOptions
     /// <summary>
     /// When set to true, the deserializer will ignore invalid enum values (and they will be implicitly left at their default value). When set to false, an exception will be thrown if the enum value is not found.
     /// </summary>
+    /// <remarks>
+    /// When deserializing dictionaries with enums as keys, invalid enum values will be skipped.
+    /// </remarks>
     public bool IgnoreInvalidEnumValues { get; set; } = false;
 }


### PR DESCRIPTION
In the case where a TomlField is being applied to a Dictionary with enum keys, there is a possibility for an exception to be thrown that can't be handled well if an invalid enum key exists in the TOML data.

Reproduction:

(with `IgnoreInvalidEnumValues` set to true)

a. Parse a TOML string with multiple invalid keys
b. Parse a TOML string with one invalid key, and at least one other valid key at the default value

Result:

a. An key is added at the default (0) value with the invalid enum's value, which is hard to detect
b. An exception is thrown when a valid key at the default (0) value also exists
c. An exception is thrown when multiple invalid keys are found

Expected:

Invalid keys should not be added to the dictionary, multiple keys should never happen

---

Changes in this PR:

- Invalid keys are no longer added to the resulting table.
- Unit tests have also been added to ensure the new behaviour works, and that it doesn't break the behaviour of multiple keys being illegal under the TOML standard.