### PR TITLE
Add an option to specify the max amount of table entries for inline tables

### DIFF
--- a/Tomlet/Models/TomlTable.cs
+++ b/Tomlet/Models/TomlTable.cs
@@ -18,12 +18,13 @@ public class TomlTable : TomlValue, IEnumerable<KeyValuePair<string, TomlValue>>
     internal bool Defined;
 
     public bool ForceNoInline { get; set; }
+    public int MaxInlineEntriesCount { get; set; } = 3;
 
     public override string StringValue => $"Table ({Entries.Count} entries)";
 
     public HashSet<string> Keys => new(Entries.Keys);
 
-    public bool ShouldBeSerializedInline => !ForceNoInline && Entries.Count < 4
+    public bool ShouldBeSerializedInline => !ForceNoInline && Entries.Count <= MaxInlineEntriesCount
                                                            && Entries.All(e => !e.Key.Contains(" ")
                                                                                && e.Value.Comments.ThereAreNoComments
                                                                                && (e.Value is TomlArray arr ? arr.IsSimpleArray : e.Value is not TomlTable));

--- a/Tomlet/TomlCompositeSerializer.cs
+++ b/Tomlet/TomlCompositeSerializer.cs
@@ -59,7 +59,7 @@ internal static class TomlCompositeSerializer
                 if (instance == null)
                     throw new ArgumentNullException(nameof(instance), "Object being serialized is null. TOML does not support null values.");
 
-                var resultTable = new TomlTable {ForceNoInline = isForcedNoInline};
+                var resultTable = new TomlTable {ForceNoInline = isForcedNoInline, MaxInlineEntriesCount = options.MaxTableEntriesCountToInline};
 
                 foreach (var field in fields)
                 {
@@ -84,8 +84,12 @@ internal static class TomlCompositeSerializer
                     tomlValue.Comments.InlineComment = thisFieldAttribs.inline?.Comment;
                     tomlValue.Comments.PrecedingComment = thisFieldAttribs.preceding?.Comment;
                     
-                    if(thisFieldAttribs.noInline != null && tomlValue is TomlTable table)
-                        table.ForceNoInline = true;
+                    if (tomlValue is TomlTable table)
+                    {
+                        table.MaxInlineEntriesCount = options.MaxTableEntriesCountToInline;
+                        if (thisFieldAttribs.noInline != null)
+                            table.ForceNoInline = true;
+                    }
 
                     resultTable.PutValue(thisFieldAttribs.field?.GetMappedString() ?? field.Name, tomlValue);
                 }
@@ -113,8 +117,12 @@ internal static class TomlCompositeSerializer
                     tomlValue.Comments.InlineComment = thisPropAttribs.inline?.Comment;
                     tomlValue.Comments.PrecedingComment = thisPropAttribs.preceding?.Comment;
 
-                    if (thisPropAttribs.noInline != null && tomlValue is TomlTable table)
-                        table.ForceNoInline = true;
+                    if (tomlValue is TomlTable table)
+                    {
+                        table.MaxInlineEntriesCount = options.MaxTableEntriesCountToInline;
+                        if (thisPropAttribs.noInline != null)
+                            table.ForceNoInline = true;
+                    }
 
                     resultTable.PutValue(thisPropAttribs.prop?.GetMappedString() ?? prop.Name, tomlValue);
                 }

--- a/Tomlet/TomlSerializerOptions.cs
+++ b/Tomlet/TomlSerializerOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace Tomlet;
+﻿using Tomlet.Models;
+
+namespace Tomlet;
 
 public class TomlSerializerOptions
 {
@@ -18,4 +20,9 @@ public class TomlSerializerOptions
     /// When set to true, the deserializer will ignore invalid enum values (and they will be implicitly left at their default value). When set to false, an exception will be thrown if the enum value is not found.
     /// </summary>
     public bool IgnoreInvalidEnumValues { get; set; } = false;
+    
+    /// <summary>
+    /// The maximum amount of entries a table may have for the table to be serialized as an inline table when <see cref="TomlTable.ForceNoInline"/> is false. The default value is 3.
+    /// </summary>
+    public int MaxTableEntriesCountToInline { get; set; } = 3;
 }


### PR DESCRIPTION
This PR adds a serialization option that allows to configure the maximum amount of entries a table may have for Tomlet to inline it. It doesn't override the existing force no inline option, but it allows to specify for the whole serialization the threshold at which Tomlet will stop inlining tables. It effectively allows to do the reverse of force no inline by setting it to 0 and setting it to int.maxvalue is equivalent to setting force no inline on the entire serialization.

The default value is the existing hardcoded one for retrocompatibility.